### PR TITLE
对基本类型参数方法支持

### DIFF
--- a/src/com/dxj/reflect/ReflectUtils.java
+++ b/src/com/dxj/reflect/ReflectUtils.java
@@ -33,6 +33,7 @@ public class ReflectUtils {
             }
         }
 
+
         if (field == null) {
             Class<?> superClass = sourceClass.getSuperclass();
             if (superClass != null) {
@@ -288,6 +289,66 @@ public class ReflectUtils {
             }
         }
         Method method = getMethod(sourceObject.getClass(), methodName, args);
+        Object result = null;
+        try {
+            if (method != null) {
+                method.setAccessible(true);
+                result = method.invoke(sourceObject, var2);
+            } else {
+                System.err.println("Method is not exist");
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+    /**
+     * 执行静态方法
+     *
+     * @param sourceClass 类
+     * @param methodName  方法名
+     * @param var2        参数
+     * @return 执行结果
+     */
+    public static Object invokeStaticMethod(Class<?> sourceClass, String methodName, Class[] argsType, Object... var2) {
+
+        Method method = getMethod(sourceClass, methodName, argsType);
+        Object result = null;
+        try {
+            if (method != null) {
+                if (isStatic(method)) {
+                    method.setAccessible(true);
+                    result = method.invoke(null, var2);
+                } else {
+                    System.err.println("method is not static");
+                }
+            } else {
+                System.err.println("Method is not exist");
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+    /**
+     * 执行类方法
+     *
+     * @param sourceObject 类对象
+     * @param methodName   方法名
+     * @param methodName   参数类型
+     * @param var2         参数
+     * @return 执行结果
+     */
+    public static Object invokeMethod(Object sourceObject, String methodName, Class[] argsType, Object... var2) {
+
+        Method method = getMethod(sourceObject.getClass(), methodName, argsType);
+
         Object result = null;
         try {
             if (method != null) {


### PR DESCRIPTION
我在使用的时候发现，调用方法或者静态方法时，如果方法的参数是基本类型，那么就会出现找不到方法的情况； 
原因是：通过参数`getClass()`获得到的是包装类，而基础类型是int.class之类的，所以通过反射是找不到对应方法的。